### PR TITLE
rearrange UI for CVE content focus

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,40 +92,42 @@ export default function Home() {
 
       </div>
 
-      <div className="flex flex-col">
-        <CveInfoCard
-          id={cveData ? cveData.id : ''}
-          sourceIdentifier={cveData ? cveData.sourceIdentifier : ''}
-          published={cveData ? cveData.published : ''}
-          lastModified={cveData ? cveData.lastModified : ''}
-          vulnStatus={cveData ? cveData.vulnStatus : ''}
-          cveTags={cveData ? cveData.cveTags : ''}
-          cisaExploitAdd={cveData ? cveData.cisaExploitAdd : ''}
-          cisaActionDue={cveData ? cveData.cisaActionDue : ''}
-          cisaRequiredAction={cveData ? cveData.cisaRequiredAction : ''}
-          cisaVulnerabilityName={cveData ? cveData.cisaVulnerabilityName : ''}
-          descriptions={cveData ? cveData.descriptions : []}
-          configurations={cveData ? cveData.configurations : []}
-          references={cveData ? cveData.references : []}
-        />
-        <CvssInfo cvssMetricV31={cvssData.cvssMetricV31} cvssMetricV2={cvssData.cvssMetricV2} />
-
-        {/* <div>
-          <CvssDisplay cvssData={cvssData} />
-        </div> */}
-        <div className="">
-          <EpssDisplay
-            cve={epssData?.cve}
-            epss={epssData?.epss}
-            percentile={epssData?.percentile}
-            date={epssData?.date}
+      <div className="flex flex-row justify-center items-start">
+        <div className="mx-10 max-w-[60%}">
+          <CveInfoCard
+            id={cveData ? cveData.id : ''}
+            sourceIdentifier={cveData ? cveData.sourceIdentifier : ''}
+            published={cveData ? cveData.published : ''}
+            lastModified={cveData ? cveData.lastModified : ''}
+            vulnStatus={cveData ? cveData.vulnStatus : ''}
+            cveTags={cveData ? cveData.cveTags : ''}
+            cisaExploitAdd={cveData ? cveData.cisaExploitAdd : ''}
+            cisaActionDue={cveData ? cveData.cisaActionDue : ''}
+            cisaRequiredAction={cveData ? cveData.cisaRequiredAction : ''}
+            cisaVulnerabilityName={cveData ? cveData.cisaVulnerabilityName : ''}
+            descriptions={cveData ? cveData.descriptions : []}
+            configurations={cveData ? cveData.configurations : []}
+            references={cveData ? cveData.references : []}
           />
         </div>
-        <div>
-          <CweDisplay 
-            cveId={cveData ? cveData.id : ''} 
-            weaknesses={cveData && cveData.weaknesses && cveData.weaknesses.length > 0 ? cveData.weaknesses : []}
-          />
+        <div className="flex flex-col mx-10 max-w-[30%]">
+          <div>
+            <CvssInfo cvssMetricV31={cvssData.cvssMetricV31} cvssMetricV2={cvssData.cvssMetricV2} />
+          </div>
+          <div className="">
+            <EpssDisplay
+              cve={epssData?.cve}
+              epss={epssData?.epss}
+              percentile={epssData?.percentile}
+              date={epssData?.date}
+            />
+          </div>
+          <div>
+            <CweDisplay
+              cveId={cveData ? cveData.id : ''}
+              weaknesses={cveData && cveData.weaknesses && cveData.weaknesses.length > 0 ? cveData.weaknesses : []}
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
content centered, focus on CVE info

The UI now follows the CVE driving the rest of the info available. CVE is the main identifier to understand vulnerabilities. CVSS and EPSS scores, CWE, CISA KEV, CPE info, and all references are all downstream of the original CVE designation.